### PR TITLE
Sphinxtrain multi-pronunciation alignment support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ BUILD_DIRS = src
 ALL_DIRS=config docbook $(BUILD_DIRS)
 CONFIG=configure configure.ac config.sub config.guess \
        missing install-sh mkinstalldirs
-OTHERS = README.md ACKNOWLEDGEMENTS COPYING
+OTHERS = README.md ACKNOWLEDGEMENTS COPYING SPHINXTRAIN_UPDATE.md
 OTHERDIRS = voices # challenges
 FILES = Makefile $(OTHERS) $(CONFIG) $(OTHERDIRS)
 

--- a/SPHINXTRAIN_UPDATE.md
+++ b/SPHINXTRAIN_UPDATE.md
@@ -26,19 +26,11 @@ $FESTVOXDIR/src/clustergen/setup_cg cmu us slt_arctic
 cp -p ../cmu_us_slt_arctic/wav/*.wav wav/
 cp -p ../cmu_us_slt_arctic/etc/txt.done.data etc/
 
-# Build prompts and label with SphinxTrain
+# Build everything (use label_sphinx instead of default label)
 ./bin/do_build build_prompts
 ./bin/do_build label_sphinx
-
-# Build utterances and ClusterGen voice
 ./bin/do_build build_utts
-./bin/do_clustergen f0
-./bin/do_clustergen mcep
-./bin/do_clustergen voicing
-./bin/do_clustergen combine_coeffs_v
-./bin/do_clustergen generate_statenames
-./bin/do_clustergen cluster
-./bin/do_clustergen dur
+./bin/do_clustergen parallel build
 
 # Test
 festival festvox/cmu_us_slt_arctic_cg.scm
@@ -46,16 +38,24 @@ festival> (voice_cmu_us_slt_arctic_cg)
 festival> (SayText "Hello world.")
 ```
 
-## Using do_build
-
-The `do_build` script provides a simple interface:
+## do_build Commands
 
 | Command | Description |
 |---------|-------------|
+| `./bin/do_build` | Run full pipeline (uses EHMM labeling) |
 | `./bin/do_build build_prompts` | Generate Festival prompt utterances |
-| `./bin/do_build label_sphinx` | Run SphinxTrain alignment (full pipeline) |
-| `./bin/do_build label` | Run EHMM alignment (alternative) |
+| `./bin/do_build label_sphinx` | Run SphinxTrain alignment (replaces `label`) |
+| `./bin/do_build label` | Run EHMM alignment (default) |
 | `./bin/do_build build_utts` | Build utterances from alignments |
+| `./bin/do_clustergen parallel build` | Build ClusterGen voice (all features) |
+
+To use SphinxTrain instead of EHMM, replace `./bin/do_build` with:
+```bash
+./bin/do_build build_prompts
+./bin/do_build label_sphinx
+./bin/do_build build_utts
+./bin/do_clustergen parallel build
+```
 
 ## What Multi-Pronunciation Does
 

--- a/SPHINXTRAIN_UPDATE.md
+++ b/SPHINXTRAIN_UPDATE.md
@@ -1,185 +1,138 @@
-# SphinxTrain Multi-Pronunciation Alignment Update
+# SphinxTrain Multi-Pronunciation Alignment
 
 *January 2026*
 
-## Overview
+The `sphinxtrain` script supports modern SphinxTrain (5.x) with multi-pronunciation
+alignment and automatic silence insertion.
 
-The `sphinxtrain` script in FestVox has been updated to support modern SphinxTrain (5.x) with multi-pronunciation alignment and automatic silence insertion. The script auto-detects available SphinxTrain versions and falls back to legacy Sphinx2 if needed.
+## Quick Start: Build Arctic SLT
 
-## What's New
+```bash
+# Set environment
+export ESTDIR=/path/to/speech_tools
+export FESTVOXDIR=/path/to/festvox
+export SPHINXTRAINDIR=/path/to/sphinxtrain
 
-### 1. Modern SphinxTrain Support
-- Uses `sphinx3_align` instead of deprecated `sphinx2-batch`
-- Uses `sphinx_fe` for feature extraction
-- Uses Python `sphinxtrain` setup script
+# Download and unpack Arctic SLT
+wget http://www.festvox.org/cmu_arctic/cmu_arctic/packed/cmu_us_slt_arctic-0.95-release.tar.bz2
+tar xjf cmu_us_slt_arctic-0.95-release.tar.bz2
 
-### 2. Multi-Pronunciation Alignment
-The aligner can now choose between alternate pronunciations based on acoustics:
+# Set up voice directory
+mkdir cmu_us_slt_arctic_cg
+cd cmu_us_slt_arctic_cg
+$FESTVOXDIR/src/clustergen/setup_cg cmu us slt_arctic
+
+# Copy data
+cp -p ../cmu_us_slt_arctic/wav/*.wav wav/
+cp -p ../cmu_us_slt_arctic/etc/txt.done.data etc/
+
+# Build prompts and label with SphinxTrain
+./bin/do_build build_prompts
+./bin/do_build label_sphinx
+
+# Build utterances and ClusterGen voice
+./bin/do_build build_utts
+./bin/do_clustergen f0
+./bin/do_clustergen mcep
+./bin/do_clustergen voicing
+./bin/do_clustergen combine_coeffs_v
+./bin/do_clustergen generate_statenames
+./bin/do_clustergen cluster
+./bin/do_clustergen dur
+
+# Test
+festival festvox/cmu_us_slt_arctic_cg.scm
+festival> (voice_cmu_us_slt_arctic_cg)
+festival> (SayText "Hello world.")
+```
+
+## Using do_build
+
+The `do_build` script provides a simple interface:
+
+| Command | Description |
+|---------|-------------|
+| `./bin/do_build build_prompts` | Generate Festival prompt utterances |
+| `./bin/do_build label_sphinx` | Run SphinxTrain alignment (full pipeline) |
+| `./bin/do_build label` | Run EHMM alignment (alternative) |
+| `./bin/do_build build_utts` | Build utterances from alignments |
+
+## What Multi-Pronunciation Does
+
+### Acoustic Pronunciation Selection
+
+When words have multiple pronunciations, SphinxTrain picks the one matching the audio:
 
 ```
-READ  r eh d     # past tense "red"
-READ(2)  r iy d  # present tense "reed"
+READ    r eh d   # past tense
+READ(2) r iy d   # present tense
 ```
 
-When aligning "I tried to READ George Moore", SphinxTrain acoustically selects `READ(2)` because the speaker says "reed".
+### Automatic Silence Insertion
 
-### 3. Automatic Silence Insertion
-SphinxTrain detects natural pauses and inserts `<sil>` markers:
+Natural pauses are detected and marked with `<sil>`:
 
 ```
 ROBBERY <sil> BRIBERY FRAUD
-THE GIRL FACED HIM <sil> HER EYES SHINING
 ```
 
-### 4. Stress Correction
-A stress map is generated to correct syllable stress when a different pronunciation variant is selected:
+### Stress Mapping
+
+Syllable stress is recorded for each variant:
 
 ```
-RECORD (1 0)     # noun: REcord
-RECORD(2) (0 1)  # verb: reCORD
+RECORD    (1 0)   # REcord (noun)
+RECORD(2) (0 1)   # reCORD (verb)
 ```
 
-If Festival predicted "REcord" but the speaker said "reCORD", the stress can be corrected during alignment merge.
+## Individual SphinxTrain Steps
 
-## Usage
-
-### Default Pipeline (Multi-Pronunciation)
+If you need more control, run steps individually:
 
 ```bash
-export SPHINXTRAINDIR=/path/to/sphinxtrain
-export ESTDIR=/path/to/speech_tools
-export FESTVOXDIR=/path/to/festvox
-
-# Run full pipeline
-bin/sphinxtrain
+./bin/sphinxtrain setup     # Initialize SphinxTrain directory
+./bin/sphinxtrain files     # Generate dict, phones, transcription
+./bin/sphinxtrain multipron # Convert to WORD(n) format
+./bin/sphinxtrain feats     # Extract MFCC features
+./bin/sphinxtrain train     # Train CI acoustic models
+./bin/sphinxtrain align     # Run forced alignment
+./bin/sphinxtrain labs      # Convert to FestVox format
 ```
-
-This runs: `setup → files → multipron → feats → train → align → labs`
-
-### Individual Steps
-
-```bash
-bin/sphinxtrain setup     # Initialize SphinxTrain directory
-bin/sphinxtrain files     # Generate dict, phones, transcription
-bin/sphinxtrain multipron # Convert to WORD(n) format
-bin/sphinxtrain feats     # Extract MFCC features
-bin/sphinxtrain train     # Train CI acoustic models
-bin/sphinxtrain align     # Run forced alignment
-bin/sphinxtrain labs      # Convert to FestVox format
-```
-
-### Legacy Mode (Sphinx2)
-
-If `SPHINX2DIR` is set and `sphinx3_align` is not found, the script falls back to legacy Sphinx2 alignment automatically.
 
 ## Output Files
 
 | File | Description |
 |------|-------------|
-| `lab/*.lab` | Phone-level alignments (FestVox format) |
+| `lab/*.lab` | Phone-level alignments |
 | `wrd/*.wrd` | Word-level alignments |
-| `st/falignout/*.alignoutput` | Selected pronunciations with WORD(n) notation |
-| `st/etc/*.stressmap` | Stress patterns for each pronunciation variant |
-| `st/phseg/*.phseg` | Raw phone segmentation from SphinxTrain |
-| `st/wdseg/*.wdseg` | Raw word segmentation from SphinxTrain |
-
-## Technical Details
-
-### Dictionary Format Conversion
-
-The `multipron` step converts Festival's format to SphinxTrain's:
-
-```
-# Festival/build_st.scm generates:
-READ  r eh d
-READ2  r iy d
-
-# multipron step converts to:
-READ  r eh d
-READ(2)  r iy d
-```
-
-### Transcript Format
-
-```
-# Original (with pre-resolved pronunciations):
-<s> I TRIED TO READ2 GEORGE MOORE </s> (arctic_a0479)
-
-# Multi-pron (base words only):
-<s> I TRIED TO READ GEORGE MOORE </s> (arctic_a0479)
-
-# Alignment output (acoustically selected):
-<s> I TRIED TO READ(2) GEORGE MOORE </s> (arctic_a0479)
-```
-
-### Stress Map Format
-
-```
-WORD (stress1 stress2 ...)
-```
-
-Examples:
-```
-FRAGMENTS (1 0)      # FRAGments
-FRAGMENTS(2) (0 1)   # fragMENTS
-PROGRESS (1 1)       # PROgress
-PROGRESS(2) (0 1)    # proGRESS
-A (0)                # schwa (unstressed)
-A(2) (1)             # letter name (stressed)
-```
-
-## Files Changed
-
-| File | Change |
-|------|--------|
-| `src/st/sphinxtrain` | Updated with modern SphinxTrain support, multi-pron |
-| `src/st/build_st_multipron.scm` | New: Generate WORD(n) format files |
-| `src/st/build_stress_map.scm` | New: Extract stress patterns |
-| `src/st/align_with_stress.scm` | New: Merge with stress correction |
+| `st/falignout/*.alignoutput` | Selected pronunciations (WORD(n) format) |
+| `st/etc/*.stressmap` | Stress patterns for variants |
 
 ## Requirements
 
-### Modern Mode (Recommended)
-- SphinxTrain 5.x with `sphinx3_align` built
-- Python 3 for `sphinxtrain` setup script
+SphinxTrain 5.x built with cmake:
 
 ```bash
-cd sphinxtrain
+cd $SPHINXTRAINDIR
 cmake -S . -B build
 cmake --build build
 ```
 
-### Legacy Mode (Fallback)
-- Sphinx2 with `sphinx2-batch`
-- Set `SPHINX2DIR` environment variable
+Verify:
 
-## Example Results
+```bash
+ls $SPHINXTRAINDIR/build/sphinx3_align
+ls $SPHINXTRAINDIR/scripts/10.falign_ci_hmm/slave_convg.pl
+```
 
-### Arctic SLT Test (1132 utterances)
+## Troubleshooting
 
-| Metric | Value |
-|--------|-------|
-| Files aligned | 1132 / 1132 (100%) |
-| Utterances with variant pronunciations | 61 |
-| Utterances with silence insertion | 225 |
-| Stress map entries | 2,985 |
+**"train" step fails or does nothing:**
 
-### Pronunciation Selection Examples
+1. Check `SPHINXTRAINDIR` is set correctly
+2. Verify `$SPHINXTRAINDIR/scripts/10.falign_ci_hmm/slave_convg.pl` exists
+3. Debug with: `bash -x bin/sphinxtrain train`
 
-| Utterance | Word | Selected | Phones |
-|-----------|------|----------|--------|
-| arctic_a0479 | READ | READ(2) | r iy d |
-| arctic_b0535 | READ | READ | r eh d |
-| arctic_a0226 | A | A(2) | ey |
+**"No mdef-file" error during alignment:**
 
-## Known Limitations
-
-1. **Dictionary coverage**: Words not in the lexicon fall back to a single pronunciation
-2. **Compound words**: May not have all variant forms
-3. **Proper names**: Limited pronunciation variants
-
-## Future Work
-
-- Integrate stress correction into `align_utt` during UTT merge
-- Add support for G2P fallback for OOV words
-- Improve compound word handling
+The train step didn't create acoustic models. Check for errors in training output.

--- a/SPHINXTRAIN_UPDATE.md
+++ b/SPHINXTRAIN_UPDATE.md
@@ -42,20 +42,15 @@ festival> (SayText "Hello world.")
 
 | Command | Description |
 |---------|-------------|
-| `./bin/do_build` | Run full pipeline (uses EHMM labeling) |
-| `./bin/do_build build_prompts` | Generate Festival prompt utterances |
-| `./bin/do_build label_sphinx` | Run SphinxTrain alignment (replaces `label`) |
-| `./bin/do_build label` | Run EHMM alignment (default) |
+| `./bin/do_build` | Full pipeline with EHMM labeling |
+| `./bin/do_build build_prompts` | Generate prompt utterances |
+| `./bin/do_build label` | EHMM alignment (default) |
+| `./bin/do_build label_sphinx` | SphinxTrain alignment (multi-pronunciation) |
 | `./bin/do_build build_utts` | Build utterances from alignments |
-| `./bin/do_clustergen parallel build` | Build ClusterGen voice (all features) |
+| `./bin/do_clustergen parallel build` | Build ClusterGen voice |
 
-To use SphinxTrain instead of EHMM, replace `./bin/do_build` with:
-```bash
-./bin/do_build build_prompts
-./bin/do_build label_sphinx
-./bin/do_build build_utts
-./bin/do_clustergen parallel build
-```
+**Note:** `./bin/do_build` (no args) uses EHMM. For SphinxTrain multi-pronunciation,
+use `label_sphinx` instead of `label` as shown in Quick Start above.
 
 ## What Multi-Pronunciation Does
 

--- a/SPHINXTRAIN_UPDATE.md
+++ b/SPHINXTRAIN_UPDATE.md
@@ -77,14 +77,11 @@ Natural pauses are detected and marked with `<sil>`:
 ROBBERY <sil> BRIBERY FRAUD
 ```
 
-### Stress Mapping
+### Stress Recovery
 
-Syllable stress is recorded for each variant:
-
-```
-RECORD    (1 0)   # REcord (noun)
-RECORD(2) (0 1)   # reCORD (verb)
-```
+When the aligner selects a variant like `RECORD(2)`, stress can be recovered directly
+from the lexicon by calling `(nth 1 (lex.lookup_all "record"))` in Festival. No separate
+stress map file is needed - the lexicon entry contains the full syllable structure with stress.
 
 ## Individual SphinxTrain Steps
 
@@ -92,13 +89,18 @@ If you need more control, run steps individually:
 
 ```bash
 ./bin/sphinxtrain setup     # Initialize SphinxTrain directory
-./bin/sphinxtrain files     # Generate dict, phones, transcription
-./bin/sphinxtrain multipron # Convert to WORD(n) format
+./bin/sphinxtrain files     # Generate dict with ALL lexicon pronunciations
+./bin/sphinxtrain multipron # Copy files for downstream compatibility
 ./bin/sphinxtrain feats     # Extract MFCC features
 ./bin/sphinxtrain train     # Train CI acoustic models
 ./bin/sphinxtrain align     # Run forced alignment
 ./bin/sphinxtrain labs      # Convert to FestVox format
 ```
+
+**Note:** The `files` step uses `build_st_multipron.scm` which calls `lex.lookup_all` to get
+ALL pronunciations from the lexicon directly. The dictionary is generated in `WORD(n)` format
+(e.g., `READ`, `READ(2)`, `READ(3)`). The `multipron` step just copies the files for
+compatibility with downstream steps that expect `.multipron.dic`.
 
 ## Output Files
 
@@ -107,7 +109,9 @@ If you need more control, run steps individually:
 | `lab/*.lab` | Phone-level alignments |
 | `wrd/*.wrd` | Word-level alignments |
 | `st/falignout/*.alignoutput` | Selected pronunciations (WORD(n) format) |
-| `st/etc/*.stressmap` | Stress patterns for variants |
+| `st/etc/*.dic` | Dictionary with all lexicon pronunciations |
+
+Stress is recovered from the lexicon directly using `lex.lookup_all` - no separate stressmap file needed.
 
 ## Requirements
 

--- a/SPHINXTRAIN_UPDATE.md
+++ b/SPHINXTRAIN_UPDATE.md
@@ -1,0 +1,185 @@
+# SphinxTrain Multi-Pronunciation Alignment Update
+
+*January 2026*
+
+## Overview
+
+The `sphinxtrain` script in FestVox has been updated to support modern SphinxTrain (5.x) with multi-pronunciation alignment and automatic silence insertion. The script auto-detects available SphinxTrain versions and falls back to legacy Sphinx2 if needed.
+
+## What's New
+
+### 1. Modern SphinxTrain Support
+- Uses `sphinx3_align` instead of deprecated `sphinx2-batch`
+- Uses `sphinx_fe` for feature extraction
+- Uses Python `sphinxtrain` setup script
+
+### 2. Multi-Pronunciation Alignment
+The aligner can now choose between alternate pronunciations based on acoustics:
+
+```
+READ  r eh d     # past tense "red"
+READ(2)  r iy d  # present tense "reed"
+```
+
+When aligning "I tried to READ George Moore", SphinxTrain acoustically selects `READ(2)` because the speaker says "reed".
+
+### 3. Automatic Silence Insertion
+SphinxTrain detects natural pauses and inserts `<sil>` markers:
+
+```
+ROBBERY <sil> BRIBERY FRAUD
+THE GIRL FACED HIM <sil> HER EYES SHINING
+```
+
+### 4. Stress Correction
+A stress map is generated to correct syllable stress when a different pronunciation variant is selected:
+
+```
+RECORD (1 0)     # noun: REcord
+RECORD(2) (0 1)  # verb: reCORD
+```
+
+If Festival predicted "REcord" but the speaker said "reCORD", the stress can be corrected during alignment merge.
+
+## Usage
+
+### Default Pipeline (Multi-Pronunciation)
+
+```bash
+export SPHINXTRAINDIR=/path/to/sphinxtrain
+export ESTDIR=/path/to/speech_tools
+export FESTVOXDIR=/path/to/festvox
+
+# Run full pipeline
+bin/sphinxtrain
+```
+
+This runs: `setup → files → multipron → feats → train → align → labs`
+
+### Individual Steps
+
+```bash
+bin/sphinxtrain setup     # Initialize SphinxTrain directory
+bin/sphinxtrain files     # Generate dict, phones, transcription
+bin/sphinxtrain multipron # Convert to WORD(n) format
+bin/sphinxtrain feats     # Extract MFCC features
+bin/sphinxtrain train     # Train CI acoustic models
+bin/sphinxtrain align     # Run forced alignment
+bin/sphinxtrain labs      # Convert to FestVox format
+```
+
+### Legacy Mode (Sphinx2)
+
+If `SPHINX2DIR` is set and `sphinx3_align` is not found, the script falls back to legacy Sphinx2 alignment automatically.
+
+## Output Files
+
+| File | Description |
+|------|-------------|
+| `lab/*.lab` | Phone-level alignments (FestVox format) |
+| `wrd/*.wrd` | Word-level alignments |
+| `st/falignout/*.alignoutput` | Selected pronunciations with WORD(n) notation |
+| `st/etc/*.stressmap` | Stress patterns for each pronunciation variant |
+| `st/phseg/*.phseg` | Raw phone segmentation from SphinxTrain |
+| `st/wdseg/*.wdseg` | Raw word segmentation from SphinxTrain |
+
+## Technical Details
+
+### Dictionary Format Conversion
+
+The `multipron` step converts Festival's format to SphinxTrain's:
+
+```
+# Festival/build_st.scm generates:
+READ  r eh d
+READ2  r iy d
+
+# multipron step converts to:
+READ  r eh d
+READ(2)  r iy d
+```
+
+### Transcript Format
+
+```
+# Original (with pre-resolved pronunciations):
+<s> I TRIED TO READ2 GEORGE MOORE </s> (arctic_a0479)
+
+# Multi-pron (base words only):
+<s> I TRIED TO READ GEORGE MOORE </s> (arctic_a0479)
+
+# Alignment output (acoustically selected):
+<s> I TRIED TO READ(2) GEORGE MOORE </s> (arctic_a0479)
+```
+
+### Stress Map Format
+
+```
+WORD (stress1 stress2 ...)
+```
+
+Examples:
+```
+FRAGMENTS (1 0)      # FRAGments
+FRAGMENTS(2) (0 1)   # fragMENTS
+PROGRESS (1 1)       # PROgress
+PROGRESS(2) (0 1)    # proGRESS
+A (0)                # schwa (unstressed)
+A(2) (1)             # letter name (stressed)
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/st/sphinxtrain` | Updated with modern SphinxTrain support, multi-pron |
+| `src/st/build_st_multipron.scm` | New: Generate WORD(n) format files |
+| `src/st/build_stress_map.scm` | New: Extract stress patterns |
+| `src/st/align_with_stress.scm` | New: Merge with stress correction |
+
+## Requirements
+
+### Modern Mode (Recommended)
+- SphinxTrain 5.x with `sphinx3_align` built
+- Python 3 for `sphinxtrain` setup script
+
+```bash
+cd sphinxtrain
+cmake -S . -B build
+cmake --build build
+```
+
+### Legacy Mode (Fallback)
+- Sphinx2 with `sphinx2-batch`
+- Set `SPHINX2DIR` environment variable
+
+## Example Results
+
+### Arctic SLT Test (1132 utterances)
+
+| Metric | Value |
+|--------|-------|
+| Files aligned | 1132 / 1132 (100%) |
+| Utterances with variant pronunciations | 61 |
+| Utterances with silence insertion | 225 |
+| Stress map entries | 2,985 |
+
+### Pronunciation Selection Examples
+
+| Utterance | Word | Selected | Phones |
+|-----------|------|----------|--------|
+| arctic_a0479 | READ | READ(2) | r iy d |
+| arctic_b0535 | READ | READ | r eh d |
+| arctic_a0226 | A | A(2) | ey |
+
+## Known Limitations
+
+1. **Dictionary coverage**: Words not in the lexicon fall back to a single pronunciation
+2. **Compound words**: May not have all variant forms
+3. **Proper names**: Limited pronunciation variants
+
+## Future Work
+
+- Integrate stress correction into `align_utt` during UTT merge
+- Add support for G2P fallback for OOV words
+- Improve compound word handling

--- a/SPHINXTRAIN_UPDATE.md
+++ b/SPHINXTRAIN_UPDATE.md
@@ -38,19 +38,25 @@ festival> (voice_cmu_us_slt_arctic_cg)
 festival> (SayText "Hello world.")
 ```
 
-## do_build Commands
+## do_build Pipeline
 
-| Command | Description |
-|---------|-------------|
-| `./bin/do_build` | Full pipeline with EHMM labeling |
-| `./bin/do_build build_prompts` | Generate prompt utterances |
-| `./bin/do_build label` | EHMM alignment (default) |
-| `./bin/do_build label_sphinx` | SphinxTrain alignment (multi-pronunciation) |
-| `./bin/do_build build_utts` | Build utterances from alignments |
-| `./bin/do_clustergen parallel build` | Build ClusterGen voice |
+Running `./bin/do_build` with no arguments builds the full voice:
 
-**Note:** `./bin/do_build` (no args) uses EHMM. For SphinxTrain multi-pronunciation,
-use `label_sphinx` instead of `label` as shown in Quick Start above.
+```bash
+./bin/do_build build_prompts   # Generate prompt utterances
+./bin/do_build label           # EHMM alignment (default)
+./bin/do_build build_utts      # Build utterances
+./bin/do_clustergen parallel build  # Build ClusterGen voice
+```
+
+To use SphinxTrain multi-pronunciation instead of EHMM, replace `label` with `label_sphinx`:
+
+```bash
+./bin/do_build build_prompts
+./bin/do_build label_sphinx    # <-- SphinxTrain instead of EHMM
+./bin/do_build build_utts
+./bin/do_clustergen parallel build
+```
 
 ## What Multi-Pronunciation Does
 

--- a/src/st/Makefile
+++ b/src/st/Makefile
@@ -36,7 +36,7 @@
 ###########################################################################
 TOP=../..
 DIRNAME=src/st
-SCMFILES = build_st.scm
+SCMFILES = build_st.scm build_st_multipron.scm build_stress_map.scm align_with_stress.scm
 SCRIPTS = sphinx_lab sphinxtrain
 FILES = Makefile  $(SCMFILES) $(SCRIPTS)
 

--- a/src/st/align_with_stress.scm
+++ b/src/st/align_with_stress.scm
@@ -1,0 +1,168 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                                                                     ;;;
+;;;                     Carnegie Mellon University                      ;;;
+;;;                         Copyright (c) 2026                          ;;;
+;;;                        All Rights Reserved.                         ;;;
+;;;                                                                     ;;;
+;;; Align utterances with SphinxTrain labels and correct stress         ;;;
+;;; based on acoustically-selected pronunciation variants               ;;;
+;;;                                                                     ;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Global stress map: maps WORD and WORD(n) to stress patterns
+(defvar *stress_map* nil)
+
+;; Load stress map from file
+;; Format: WORD (stress1 stress2 ...)
+(define (load_stress_map filename)
+  (set! *stress_map* nil)
+  (let ((fd (fopen filename "r"))
+        line word stress)
+    (while (set! line (readfp fd))
+      ;; Parse: WORD followed by stress list
+      (if (and (consp line) (> (length line) 1))
+          (let ((word (car line))
+                (stress (cadr line)))
+            (set! *stress_map* (cons (list word stress) *stress_map*)))))
+    (fclose fd))
+  (format t "Loaded %d stress mappings\n" (length *stress_map*)))
+
+;; Look up stress pattern for a word variant
+(define (get_stress word_variant)
+  (let ((entry (assoc_string word_variant *stress_map*)))
+    (if entry
+        (cadr entry)
+        nil)))
+
+;; Parse SphinxTrain alignoutput line to get word->variant mapping
+;; Format: <s> <s> WORD1 WORD2(2) WORD3 <sil> WORD4 </s> </s> (uttid)
+(define (parse_alignoutput_line line)
+  (let ((result nil)
+        (words (string-split line " ")))
+    ;; Skip <s> markers and extract words
+    (mapcar
+     (lambda (w)
+       (if (and (not (string-matches w "<.*>"))
+                (not (string-matches w "\\(.*\\)")))
+           (set! result (cons w result))))
+     words)
+    (reverse result)))
+
+;; Get the selected variant for a word from alignoutput
+;; Returns the variant string (e.g., "READ" or "READ(2)")
+(define (get_selected_variant word alignoutput_words)
+  (let ((found nil))
+    (mapcar
+     (lambda (w)
+       ;; Match base word (with or without (n) suffix)
+       (if (or (string-equal (upcase word) w)
+               (string-matches w (string-append (upcase word) "\\([0-9]+\\)")))
+           (set! found w)))
+     alignoutput_words)
+    found))
+
+;; Update syllable stress for a word based on selected variant
+(define (update_word_stress word_item variant)
+  (let ((stress_pattern (get_stress variant)))
+    (if stress_pattern
+        (let ((syls (item.daughters
+                     (item.relation.parent word_item 'SylStructure)))
+              (i 0))
+          (mapcar
+           (lambda (syl)
+             (if (< i (length stress_pattern))
+                 (begin
+                   (item.set_feat syl "stress"
+                                  (nth i stress_pattern))
+                   (set! i (+ i 1)))))
+           syls)
+          (if (not (eq? i (length stress_pattern)))
+              (format t "Warning: stress mismatch for %s (%d syls, %d stress)\n"
+                      variant i (length stress_pattern)))))))
+
+;; Main alignment function with stress correction
+(define (align_utt_with_stress name lab_file alignoutput_line)
+  (let ((utt (utt.load nil (format nil "festival/utts/%s.utt" name)))
+        (silence (car (cadr (car (PhoneSet.description '(silences))))))
+        (alignoutput_words (parse_alignoutput_line alignoutput_line))
+        segments actual-segments)
+
+    ;; Load lab file
+    (utt.relation.load utt 'actual-segment lab_file)
+    (set! segments (utt.relation.items utt 'Segment))
+    (set! actual-segments (utt.relation.items utt 'actual-segment))
+
+    ;; Merge phone timing (standard alignment)
+    (while (and segments actual-segments)
+      (cond
+       ;; Lab has extra silence - insert
+       ((and (not (string-equal (item.name (car segments))
+                                (item.name (car actual-segments))))
+             (or (string-equal (item.name (car actual-segments)) silence)
+                 (string-equal (item.name (car actual-segments)) "ssil")))
+        (item.insert
+         (car segments)
+         (list silence (list (list "end" (item.feat
+                                          (car actual-segments) "end"))))
+         'before)
+        (set! actual-segments (cdr actual-segments)))
+       ;; UTT has extra silence - delete
+       ((and (not (string-equal (item.name (car segments))
+                                (item.name (car actual-segments))))
+             (string-equal (item.name (car segments)) silence))
+        (item.delete (car segments))
+        (set! segments (cdr segments)))
+       ;; Match - copy timing
+       ((string-equal (item.name (car segments))
+                      (item.name (car actual-segments)))
+        (item.set_feat (car segments) "end"
+                       (item.feat (car actual-segments) "end"))
+        (set! segments (cdr segments))
+        (set! actual-segments (cdr actual-segments)))
+       (t
+        (format t "Align mismatch: %s vs %s\n"
+                (item.name (car segments))
+                (item.name (car actual-segments)))
+        (set! segments nil))))
+
+    ;; Update stress based on selected variants
+    (mapcar
+     (lambda (word_item)
+       (let ((word (item.name word_item))
+             (variant (get_selected_variant word alignoutput_words)))
+         (if (and variant (string-matches variant ".*\\([0-9]+\\)"))
+             (begin
+               (format t "Updating stress for %s -> %s\n" word variant)
+               (update_word_stress word_item variant)))))
+     (utt.relation.items utt 'Word))
+
+    utt))
+
+;; Process all utterances
+(define (align_all_with_stress datafile lab_dir alignoutput_file stressmap_file)
+  (load_stress_map stressmap_file)
+
+  ;; Load alignoutput into hash
+  (let ((alignoutput_hash (make-hash-table))
+        (fd (fopen alignoutput_file "r"))
+        line)
+    (while (set! line (fgets fd))
+      (if (string-matches line ".*\\(arctic_.*\\)")
+          (let ((uttid (string-after (string-before line ")") "(")))
+            (hash-set! alignoutput_hash uttid line))))
+    (fclose fd)
+
+    ;; Process each utterance
+    (mapcar
+     (lambda (p)
+       (let ((uttid (car p))
+             (alignline (hash-ref alignoutput_hash (car p))))
+         (format t "Processing %s\n" uttid)
+         (if alignline
+             (align_utt_with_stress uttid
+                                    (format nil "%s/%s.lab" lab_dir uttid)
+                                    alignline)
+             (format t "Warning: no alignoutput for %s\n" uttid))))
+     (load datafile t))))
+
+(provide 'align_with_stress)

--- a/src/st/build_st_multipron.scm
+++ b/src/st/build_st_multipron.scm
@@ -32,14 +32,17 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Multi-pronunciation SphinxTrain setup
-;;; - Dictionary has WORD and WORD(2) format for alternatives
-;;; - Transcript has base word forms only
-;;; - Aligner chooses best pronunciation
+;;;
+;;; Uses ALL pronunciations from the lexicon for each word, allowing
+;;; the aligner to select the best variant acoustically. Stress can
+;;; be recovered from the selected variant (e.g., RECORD(2)) by
+;;; looking up the corresponding lexicon entry via lex.lookup_all.
 ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (st_multipron_setup datafile vname)
-  "Main entry point for multi-pronunciation SphinxTrain setup"
+  "Main entry point for multi-pronunciation SphinxTrain setup.
+   Generates dictionary with all lexicon pronunciations for each word."
   (let ((words-seen nil)
         (phones-seen nil)
         (silence (car (cadr (car (PhoneSet.description '(silences))))))
@@ -49,39 +52,52 @@
         (ifd (fopen (format nil "st/etc/%s.fileids" vname) "w"))
         (tfd (fopen (format nil "st/etc/%s.transcription" vname) "w")))
 
-    ;; Process each utterance
+    ;; First pass: collect unique words and write transcripts/fileids
+    (format t "Pass 1: Collecting words from corpus...\n")
     (mapcar
      (lambda (p)
        (let ((uttid (car p))
              (utt (utt.load nil (format nil "prompt-utt/%s.utt" (car p)))))
          (format t "%s\n" uttid)
-
-         ;; Write file ID
          (format ifd "%s\n" uttid)
-
-         ;; Write transcript with base word forms only
          (format tfd "<s>")
          (mapcar
           (lambda (w)
             (let ((word (item.name w))
                   (nicename (make_nicename (item.name w))))
-              ;; Add word to transcript (base form, uppercase)
               (format tfd " %s" nicename)
-              ;; Collect word and its pronunciation for dictionary
-              (set! words-seen (add_word_pron words-seen nicename
-                                              (get_word_phones w silence)
-                                              phones-seen))
-              (set! phones-seen (cadr words-seen))
-              (set! words-seen (car words-seen))))
+              (if (not (member_string word words-seen))
+                  (set! words-seen (cons word words-seen)))))
           (utt.relation.items utt 'Word))
          (format tfd " </s> (%s)\n" uttid)))
      (load datafile t))
-
     (fclose tfd)
     (fclose ifd)
 
-    ;; Write dictionary with multiple pronunciations
-    (write_multipron_dict dfd words-seen)
+    ;; Second pass: get ALL lexicon pronunciations for each word
+    (format t "\nPass 2: Getting all lexicon pronunciations for %d words...\n"
+            (length words-seen))
+    (mapcar
+     (lambda (word)
+       (let ((nicename (make_nicename word))
+             (entries (lex.lookup_all word))
+             (n 1))
+         (mapcar
+          (lambda (entry)
+            (let ((pron (flatten_phones entry)))
+              ;; Track phones for phone list
+              (mapcar
+               (lambda (ph)
+                 (if (not (member_string ph phones-seen))
+                     (set! phones-seen (cons ph phones-seen))))
+               (string-split pron " "))
+              ;; Write dictionary entry: WORD or WORD(n)
+              (if (eq? n 1)
+                  (format dfd "%s  %s\n" nicename pron)
+                  (format dfd "%s(%d)  %s\n" nicename n pron))
+              (set! n (+ n 1))))
+          entries)))
+     words-seen)
     (fclose dfd)
 
     ;; Write phone list
@@ -96,13 +112,15 @@
     ;; Write filler dictionary
     (format ffd "<s> SIL\n")
     (format ffd "</s> SIL\n")
-    (format ffd "<sil> SIL\n")  ;; For optional silence insertion
+    (format ffd "<sil> SIL\n")
     (fclose ffd)
 
     ;; Write silence phone name
     (let ((sfd (fopen "etc/mysilence" "w")))
       (format sfd "%s\n" silence)
-      (fclose sfd))))
+      (fclose sfd))
+
+    (format t "Done. Dictionary contains all lexicon pronunciations.\n")))
 
 (define (make_nicename word)
   "Convert word to SphinxTrain-friendly uppercase name"
@@ -119,100 +137,10 @@
         (set! lets (list "X" (length lets) "Q")))
     (apply string-append (reverse lets))))
 
-(define (get_word_phones word silence)
-  "Extract phone sequence for a word from its segments"
-  (let ((phones nil))
-    (mapcar
-     (lambda (seg)
-       (let ((ph (item.name seg)))
-         (if (not (string-equal ph silence))
-             (set! phones (cons (make_nicephone seg) phones)))))
-     (item.daughters (item.relation.daughter1 word 'SylStructure)))
-    (reverse phones)))
-
-(define (make_nicephone seg)
-  "Convert phone name for SphinxTrain (handle case issues)"
-  (let ((ph (item.name seg)))
-    (if (string-matches ph ".*[A-Z].*")
-        (string-append "CAP" ph)
-        ph)))
-
-(define (add_word_pron words-seen nicename phones phones-seen)
-  "Add word and pronunciation to collection, tracking alternatives"
-  ;; Update phones-seen with any new phones
-  (mapcar
-   (lambda (ph)
-     (if (not (member_string ph phones-seen))
-         (set! phones-seen (cons ph phones-seen))))
-   phones)
-
-  (let ((pron-str (apply string-append
-                         (cons (car phones)
-                               (mapcar (lambda (p) (string-append " " p))
-                                       (cdr phones)))))
-        (entry (assoc_string nicename words-seen)))
-    (if entry
-        ;; Word exists - check if this is a new pronunciation
-        (if (not (member_string pron-str (cdr entry)))
-            (set-cdr! entry (cons pron-str (cdr entry))))
-        ;; New word
-        (set! words-seen (cons (list nicename pron-str) words-seen))))
-  (list words-seen phones-seen))
-
-(define (write_multipron_dict fd words)
-  "Write dictionary with WORD(n) format for multiple pronunciations"
-  (mapcar
-   (lambda (entry)
-     (let ((word (car entry))
-           (prons (cdr entry))
-           (n 1))
-       (mapcar
-        (lambda (pron)
-          (if (eq? n 1)
-              (format fd "%s  %s\n" word pron)
-              (format fd "%s(%d)  %s\n" word n pron))
-          (set! n (+ n 1)))
-        (reverse prons))))  ;; Reverse to keep first-seen as base
-   words))
-
-;; Also dump ALL pronunciations from the lexicon for words in corpus
-(define (st_dump_lexicon_prons datafile vname)
-  "Dump all lexicon pronunciations for words in corpus"
-  (let ((words-seen nil)
-        (dfd (fopen (format nil "st/etc/%s.fulldict" vname) "w")))
-
-    ;; Collect all words from utterances
-    (mapcar
-     (lambda (p)
-       (let ((utt (utt.load nil (format nil "prompt-utt/%s.utt" (car p)))))
-         (mapcar
-          (lambda (w)
-            (let ((word (item.name w)))
-              (if (not (member_string word words-seen))
-                  (set! words-seen (cons word words-seen)))))
-          (utt.relation.items utt 'Word))))
-     (load datafile t))
-
-    ;; For each word, get ALL pronunciations from lexicon
-    (mapcar
-     (lambda (word)
-       (let ((nicename (make_nicename word))
-             (entries (lex.lookup_all word))
-             (n 1))
-         (mapcar
-          (lambda (entry)
-            (let ((phones (flatten_phones entry)))
-              (if (eq? n 1)
-                  (format dfd "%s  %s\n" nicename phones)
-                  (format dfd "%s(%d)  %s\n" nicename n phones))
-              (set! n (+ n 1))))
-          entries)))
-     words-seen)
-
-    (fclose dfd)))
-
 (define (flatten_phones entry)
-  "Flatten Festival lexicon entry to phone string"
+  "Flatten Festival lexicon entry to phone string.
+   Entry format: (word pos (((ph1 ph2) stress) ((ph3) stress) ...))
+   Returns space-separated phone string."
   (let ((phones nil))
     (mapcar
      (lambda (syl)
@@ -225,5 +153,24 @@
            (cons (car (reverse phones))
                  (mapcar (lambda (p) (string-append " " p))
                          (cdr (reverse phones)))))))
+
+(define (string-split str delim)
+  "Split string by delimiter into list of strings"
+  (let ((result nil)
+        (current "")
+        (i 0)
+        (len (length str)))
+    (while (< i len)
+      (let ((c (substring str i 1)))
+        (if (string-equal c delim)
+            (begin
+              (if (> (length current) 0)
+                  (set! result (cons current result)))
+              (set! current ""))
+            (set! current (string-append current c))))
+      (set! i (+ i 1)))
+    (if (> (length current) 0)
+        (set! result (cons current result)))
+    (reverse result)))
 
 (provide 'build_st_multipron)

--- a/src/st/build_st_multipron.scm
+++ b/src/st/build_st_multipron.scm
@@ -1,0 +1,229 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                                                                     ;;;
+;;;                     Carnegie Mellon University                      ;;;
+;;;                  and Alan W Black and Kevin Lenzo                   ;;;
+;;;                      Copyright (c) 1998-2026                        ;;;
+;;;                        All Rights Reserved.                         ;;;
+;;;                                                                     ;;;
+;;; Permission is hereby granted, free of charge, to use and distribute ;;;
+;;; this software and its documentation without restriction, including  ;;;
+;;; without limitation the rights to use, copy, modify, merge, publish, ;;;
+;;; distribute, sublicense, and/or sell copies of this work, and to     ;;;
+;;; permit persons to whom this work is furnished to do so, subject to  ;;;
+;;; the following conditions:                                           ;;;
+;;;  1. The code must retain the above copyright notice, this list of   ;;;
+;;;     conditions and the following disclaimer.                        ;;;
+;;;  2. Any modifications must be clearly marked as such.               ;;;
+;;;  3. Original authors' names are not deleted.                        ;;;
+;;;  4. The authors' names are not used to endorse or promote products  ;;;
+;;;     derived from this software without specific prior written       ;;;
+;;;     permission.                                                     ;;;
+;;;                                                                     ;;;
+;;; CARNEGIE MELLON UNIVERSITY AND THE CONTRIBUTORS TO THIS WORK        ;;;
+;;; DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING     ;;;
+;;; ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT  ;;;
+;;; SHALL CARNEGIE MELLON UNIVERSITY NOR THE CONTRIBUTORS BE LIABLE     ;;;
+;;; FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES   ;;;
+;;; WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN  ;;;
+;;; AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,         ;;;
+;;; ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF      ;;;
+;;; THIS SOFTWARE.                                                      ;;;
+;;;                                                                     ;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Multi-pronunciation SphinxTrain setup
+;;; - Dictionary has WORD and WORD(2) format for alternatives
+;;; - Transcript has base word forms only
+;;; - Aligner chooses best pronunciation
+;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define (st_multipron_setup datafile vname)
+  "Main entry point for multi-pronunciation SphinxTrain setup"
+  (let ((words-seen nil)
+        (phones-seen nil)
+        (silence (car (cadr (car (PhoneSet.description '(silences))))))
+        (pfd (fopen (format nil "st/etc/%s.phone" vname) "w"))
+        (dfd (fopen (format nil "st/etc/%s.dic" vname) "w"))
+        (ffd (fopen (format nil "st/etc/%s.filler" vname) "w"))
+        (ifd (fopen (format nil "st/etc/%s.fileids" vname) "w"))
+        (tfd (fopen (format nil "st/etc/%s.transcription" vname) "w")))
+
+    ;; Process each utterance
+    (mapcar
+     (lambda (p)
+       (let ((uttid (car p))
+             (utt (utt.load nil (format nil "prompt-utt/%s.utt" (car p)))))
+         (format t "%s\n" uttid)
+
+         ;; Write file ID
+         (format ifd "%s\n" uttid)
+
+         ;; Write transcript with base word forms only
+         (format tfd "<s>")
+         (mapcar
+          (lambda (w)
+            (let ((word (item.name w))
+                  (nicename (make_nicename (item.name w))))
+              ;; Add word to transcript (base form, uppercase)
+              (format tfd " %s" nicename)
+              ;; Collect word and its pronunciation for dictionary
+              (set! words-seen (add_word_pron words-seen nicename
+                                              (get_word_phones w silence)
+                                              phones-seen))
+              (set! phones-seen (cadr words-seen))
+              (set! words-seen (car words-seen))))
+          (utt.relation.items utt 'Word))
+         (format tfd " </s> (%s)\n" uttid)))
+     (load datafile t))
+
+    (fclose tfd)
+    (fclose ifd)
+
+    ;; Write dictionary with multiple pronunciations
+    (write_multipron_dict dfd words-seen)
+    (fclose dfd)
+
+    ;; Write phone list
+    (mapcar
+     (lambda (ph)
+       (if (not (string-equal silence ph))
+           (format pfd "%s\n" ph)))
+     phones-seen)
+    (format pfd "SIL\n")
+    (fclose pfd)
+
+    ;; Write filler dictionary
+    (format ffd "<s> SIL\n")
+    (format ffd "</s> SIL\n")
+    (format ffd "<sil> SIL\n")  ;; For optional silence insertion
+    (fclose ffd)
+
+    ;; Write silence phone name
+    (let ((sfd (fopen "etc/mysilence" "w")))
+      (format sfd "%s\n" silence)
+      (fclose sfd))))
+
+(define (make_nicename word)
+  "Convert word to SphinxTrain-friendly uppercase name"
+  (let ((ws (format nil "%s" word))
+        (lets nil)
+        (p 0))
+    (while (< p (length ws))
+      (let ((c (substring ws p 1)))
+        (if (string-matches c "[A-Za-z0-9']")
+            (set! lets (cons (upcase c) lets))
+            (set! lets (cons "Q" lets))))
+      (set! p (+ 1 p)))
+    (if (> (length lets) 20)
+        (set! lets (list "X" (length lets) "Q")))
+    (apply string-append (reverse lets))))
+
+(define (get_word_phones word silence)
+  "Extract phone sequence for a word from its segments"
+  (let ((phones nil))
+    (mapcar
+     (lambda (seg)
+       (let ((ph (item.name seg)))
+         (if (not (string-equal ph silence))
+             (set! phones (cons (make_nicephone seg) phones)))))
+     (item.daughters (item.relation.daughter1 word 'SylStructure)))
+    (reverse phones)))
+
+(define (make_nicephone seg)
+  "Convert phone name for SphinxTrain (handle case issues)"
+  (let ((ph (item.name seg)))
+    (if (string-matches ph ".*[A-Z].*")
+        (string-append "CAP" ph)
+        ph)))
+
+(define (add_word_pron words-seen nicename phones phones-seen)
+  "Add word and pronunciation to collection, tracking alternatives"
+  ;; Update phones-seen with any new phones
+  (mapcar
+   (lambda (ph)
+     (if (not (member_string ph phones-seen))
+         (set! phones-seen (cons ph phones-seen))))
+   phones)
+
+  (let ((pron-str (apply string-append
+                         (cons (car phones)
+                               (mapcar (lambda (p) (string-append " " p))
+                                       (cdr phones)))))
+        (entry (assoc_string nicename words-seen)))
+    (if entry
+        ;; Word exists - check if this is a new pronunciation
+        (if (not (member_string pron-str (cdr entry)))
+            (set-cdr! entry (cons pron-str (cdr entry))))
+        ;; New word
+        (set! words-seen (cons (list nicename pron-str) words-seen))))
+  (list words-seen phones-seen))
+
+(define (write_multipron_dict fd words)
+  "Write dictionary with WORD(n) format for multiple pronunciations"
+  (mapcar
+   (lambda (entry)
+     (let ((word (car entry))
+           (prons (cdr entry))
+           (n 1))
+       (mapcar
+        (lambda (pron)
+          (if (eq? n 1)
+              (format fd "%s  %s\n" word pron)
+              (format fd "%s(%d)  %s\n" word n pron))
+          (set! n (+ n 1)))
+        (reverse prons))))  ;; Reverse to keep first-seen as base
+   words))
+
+;; Also dump ALL pronunciations from the lexicon for words in corpus
+(define (st_dump_lexicon_prons datafile vname)
+  "Dump all lexicon pronunciations for words in corpus"
+  (let ((words-seen nil)
+        (dfd (fopen (format nil "st/etc/%s.fulldict" vname) "w")))
+
+    ;; Collect all words from utterances
+    (mapcar
+     (lambda (p)
+       (let ((utt (utt.load nil (format nil "prompt-utt/%s.utt" (car p)))))
+         (mapcar
+          (lambda (w)
+            (let ((word (item.name w)))
+              (if (not (member_string word words-seen))
+                  (set! words-seen (cons word words-seen)))))
+          (utt.relation.items utt 'Word))))
+     (load datafile t))
+
+    ;; For each word, get ALL pronunciations from lexicon
+    (mapcar
+     (lambda (word)
+       (let ((nicename (make_nicename word))
+             (entries (lex.lookup_all word))
+             (n 1))
+         (mapcar
+          (lambda (entry)
+            (let ((phones (flatten_phones entry)))
+              (if (eq? n 1)
+                  (format dfd "%s  %s\n" nicename phones)
+                  (format dfd "%s(%d)  %s\n" nicename n phones))
+              (set! n (+ n 1))))
+          entries)))
+     words-seen)
+
+    (fclose dfd)))
+
+(define (flatten_phones entry)
+  "Flatten Festival lexicon entry to phone string"
+  (let ((phones nil))
+    (mapcar
+     (lambda (syl)
+       (mapcar
+        (lambda (ph)
+          (set! phones (cons (format nil "%s" ph) phones)))
+        (car syl)))
+     (caddr entry))
+    (apply string-append
+           (cons (car (reverse phones))
+                 (mapcar (lambda (p) (string-append " " p))
+                         (cdr (reverse phones)))))))
+
+(provide 'build_st_multipron)

--- a/src/st/build_stress_map.scm
+++ b/src/st/build_stress_map.scm
@@ -1,0 +1,68 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;                                                                     ;;;
+;;;                     Carnegie Mellon University                      ;;;
+;;;                         Copyright (c) 2026                          ;;;
+;;;                        All Rights Reserved.                         ;;;
+;;;                                                                     ;;;
+;;; Generate stress mapping for multi-pronunciation alignment           ;;;
+;;; Maps WORD(n) variants to syllable stress patterns                   ;;;
+;;;                                                                     ;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Extract stress pattern from Festival lexicon entry
+;; Entry format: ("word" pos (((phones) stress) ((phones) stress) ...))
+;; Returns list of stress values: (1 0) for REcord, (0 1) for reCORD
+(define (get_stress_pattern entry)
+  (mapcar (lambda (syl) (car (cdr syl))) (car (cdr (cdr entry)))))
+
+;; Generate stress map for all words in corpus
+;; Output format: WORD(n) stress1 stress2 ...
+(define (build_stress_map datafile outfile)
+  (let ((words_seen nil)
+        (ofd (fopen outfile "w")))
+
+    ;; Collect words from corpus
+    (mapcar
+     (lambda (p)
+       (let ((utt (utt.load nil (format nil "prompt-utt/%s.utt" (car p)))))
+         (mapcar
+          (lambda (w)
+            (let ((word (item.name w)))
+              (if (not (member_string word words_seen))
+                  (set! words_seen (cons word words_seen)))))
+          (utt.relation.items utt 'Word))))
+     (load datafile t))
+
+    ;; For each word, get all pronunciations and their stress patterns
+    (mapcar
+     (lambda (word)
+       (let ((entries (lex.lookup_all word))
+             (nicename (make_nicename word))
+             (n 1))
+         (mapcar
+          (lambda (entry)
+            (let ((stress (get_stress_pattern entry)))
+              ;; Write mapping: WORD(n) stress1 stress2 ...
+              (if (eq? n 1)
+                  (format ofd "%s %l\n" nicename stress)
+                  (format ofd "%s(%d) %l\n" nicename n stress))
+              (set! n (+ n 1))))
+          entries)))
+     words_seen)
+
+    (fclose ofd)))
+
+;; Helper to convert word to SphinxTrain format
+(define (make_nicename word)
+  (let ((ws (format nil "%s" word))
+        (lets nil)
+        (p 0))
+    (while (< p (length ws))
+      (let ((c (substring ws p 1)))
+        (if (string-matches c "[A-Za-z0-9']")
+            (set! lets (cons (upcase c) lets))
+            (set! lets (cons "Q" lets))))
+      (set! p (+ 1 p)))
+    (apply string-append (reverse lets))))
+
+(provide 'build_stress_map)

--- a/src/st/sphinxtrain
+++ b/src/st/sphinxtrain
@@ -3,7 +3,7 @@
 ##                                                                       ##
 ##                  Language Technologies Institute                      ##
 ##                     Carnegie Mellon University                        ##
-##                         Copyright (c) 2002                            ##
+##                     Copyright (c) 2002-2026                           ##
 ##                        All Rights Reserved.                           ##
 ##                                                                       ##
 ##  Permission is hereby granted, free of charge, to use and distribute  ##
@@ -32,8 +32,8 @@
 ##                                                                       ##
 ###########################################################################
 ##                                                                       ##
-##  Run SphinxTrain on data to build acoustic models then label it       ##
-##  with forced alignment                                                ##
+##  Run SphinxTrain for forced alignment with multiple pronunciations    ##
+##  Uses sphinx3_align (modern) or sphinx2-batch (legacy fallback)       ##
 ##                                                                       ##
 ###########################################################################
 
@@ -46,36 +46,73 @@ then
    echo "environment variable ESTDIR is unset"
    echo "set it to your local speech tools directory e.g."
    echo '   bash$ export ESTDIR=/home/awb/projects/speech_tools/'
-   echo or
-   echo '   csh% setenv ESTDIR /home/awb/projects/speech_tools/'
    exit 1
 fi
 
 if [ ! "$SPHINXTRAINDIR" ]
 then
    echo "environment variable SPHINXTRAINDIR is unset"
-   echo "set it to your local SphinxTrain src directory e.g."
-   echo '   bash$ export SPHINXTRAINDIR=/home/awb/projects/SphinxTrain/'
-   echo or
-   echo '   csh% setenv SPHINXTRAINDIR /home/awb/projects/SphinxTrain/'
+   echo "set it to your SphinxTrain source directory e.g."
+   echo '   bash$ export SPHINXTRAINDIR=/home/awb/projects/sphinxtrain/'
    exit 1
 fi
 
-if [ ! "$SPHINX2DIR" ]
+# Detect SphinxTrain version and set up paths
+USE_SPHINX3=0
+
+# Check for sphinx3_align (modern SphinxTrain 5.x)
+if [ -x "$SPHINXTRAINDIR/build/sphinx3_align" ]
 then
-   echo "environment variable SPHINX2DIR is unset"
-   echo "set it to your local Sphinx2 is installed e.g."
-   echo '   bash$ export SPHINX2DIR=/home/awb/projects/sphinx2/'
-   echo or
-   echo '   csh% setenv SPHINX2DIR /home/awb/projects/sphinx2/'
-   echo 'such that $SPHINX2DIR/bin/sphinx2-batch exists'
+   SPHINX3_ALIGN="$SPHINXTRAINDIR/build/sphinx3_align"
+   USE_SPHINX3=1
+elif [ -x "$SPHINXTRAINDIR/bin/sphinx3_align" ]
+then
+   SPHINX3_ALIGN="$SPHINXTRAINDIR/bin/sphinx3_align"
+   USE_SPHINX3=1
+fi
+
+# Check for sphinx_fe
+if [ -x "$SPHINXTRAINDIR/build/sphinx_fe" ]
+then
+   SPHINX_FE="$SPHINXTRAINDIR/build/sphinx_fe"
+elif [ -x "$SPHINXTRAINDIR/bin/sphinx_fe" ]
+then
+   SPHINX_FE="$SPHINXTRAINDIR/bin/sphinx_fe"
+fi
+
+# Check for sphinxtrain python script (modern)
+if [ -x "$SPHINXTRAINDIR/scripts/sphinxtrain" ]
+then
+   SPHINXTRAIN_PY="python3 $SPHINXTRAINDIR/scripts/sphinxtrain"
+fi
+
+# Legacy: Check for Sphinx2 (fallback)
+if [ "$SPHINX2DIR" ] && [ -x "$SPHINX2DIR/bin/sphinx2-batch" ]
+then
+   USE_SPHINX2=1
+else
+   USE_SPHINX2=0
+fi
+
+if [ "$USE_SPHINX3" = 1 ]
+then
+   echo "Using modern SphinxTrain (sphinx3_align)"
+elif [ "$USE_SPHINX2" = 1 ]
+then
+   echo "Using legacy Sphinx2 (sphinx2-batch)"
+else
+   echo "Error: Cannot find sphinx3_align or sphinx2-batch"
+   echo "For modern SphinxTrain: cmake -S . -B build && cmake --build build"
+   echo "Or set SPHINX2DIR for legacy support"
    exit 1
 fi
 
+# Default pipeline: multi-pronunciation with silence insertion
 if [ $# = 0 ]
 then
    $0 setup
    $0 files
+   $0 multipron
    $0 feats
    $0 train
    $0 align
@@ -85,74 +122,312 @@ fi
 
 if [ "$1" = "setup" ]
 then
-  mkdir st
-  cd st
+   echo "SphinxTrain setup"
+   mkdir -p st
+   cd st
 
-  $SPHINXTRAINDIR/scripts_pl/setup_SphinxTrain $FV_VOICENAME
-  mkdir lab
+   if [ "$USE_SPHINX3" = 1 ] && [ "$SPHINXTRAIN_PY" ]
+   then
+      # Modern setup
+      $SPHINXTRAIN_PY -t $FV_VOICENAME setup
+   else
+      # Legacy setup
+      $SPHINXTRAINDIR/scripts_pl/setup_SphinxTrain.pl $FV_VOICENAME 2>/dev/null || \
+      $SPHINXTRAINDIR/scripts_pl/setup_SphinxTrain $FV_VOICENAME
+   fi
 
-  cd ..
+   mkdir -p lab wav
+   cd ..
 fi
 
-#  dic, fileids, phone, filler, transcription
+# Generate dictionary, phone list, transcription files
 if [ "$1" = "files" ]
 then
+   echo "Generating SphinxTrain input files"
    festival -b festvox/build_st.scm '(st_setup "etc/txt.done.data" "'$FV_VOICENAME'")'
+
+   # Copy to expected locations
+   cp st/etc/$FV_VOICENAME.phone st/etc/${FV_VOICENAME}.phone 2>/dev/null
+   cp st/etc/$FV_VOICENAME.fileids st/etc/${FV_VOICENAME}_train.fileids 2>/dev/null
+   cp st/etc/$FV_VOICENAME.transcription st/etc/${FV_VOICENAME}_train.transcription 2>/dev/null
 fi
 
-# Wave 2 feats
+# Convert to multi-pronunciation format (WORD2 -> WORD(2))
+if [ "$1" = "multipron" ]
+then
+   echo "Creating multi-pronunciation dictionary and transcript"
+   cd st
+
+   # Convert dict: WORD2 -> WORD(2) format for SphinxTrain
+   sed -E 's/^([A-Z]+Q?)([0-9]+)  /\1(\2)  /' etc/$FV_VOICENAME.dic \
+      > etc/$FV_VOICENAME.multipron.dic
+
+   # Convert transcript: strip trailing digits from words
+   sed -E 's/([A-Z]+Q?)[0-9]+/\1/g' etc/$FV_VOICENAME.transcription \
+      > etc/$FV_VOICENAME.multipron.transcription
+
+   cd ..
+
+   # Generate stress map for pronunciation variants
+   echo "Generating stress map for pronunciation variants..."
+   if [ -f "$FESTVOXDIR/src/st/build_stress_map.scm" ]; then
+      cp $FESTVOXDIR/src/st/build_stress_map.scm festvox/
+   fi
+
+   if [ -f "festvox/build_stress_map.scm" ]; then
+      festival -b festvox/build_stress_map.scm \
+         '(build_stress_map "etc/txt.done.data" "st/etc/'$FV_VOICENAME'.stressmap")'
+   fi
+
+   echo "Created:"
+   echo "  st/etc/$FV_VOICENAME.multipron.dic - WORD(n) format dictionary"
+   echo "  st/etc/$FV_VOICENAME.multipron.transcription - base word forms"
+   echo "  st/etc/$FV_VOICENAME.stressmap - stress patterns for variants"
+fi
+
+# Extract features
 if [ "$1" = "feats" ]
 then
-   find wav -name \*.wav -print |
-   while read i
+   echo "Extracting features"
+
+   # Convert wav files to st/wav/ in NIST format (16kHz)
+   for wav in wav/*.wav
    do
-      $ESTDIR/bin/ch_wave -otype nist -F 16000 -o st/$i $i
+      base=$(basename $wav .wav)
+      if [ ! -f st/wav/$base.wav ]
+      then
+         $ESTDIR/bin/ch_wave -otype nist -F 16000 -o st/wav/$base.wav $wav
+      fi
    done
-   (cd st; ./bin/make_feats etc/$FV_VOICENAME.fileids)
+
+   cd st
+
+   if [ "$USE_SPHINX3" = 1 ] && [ "$SPHINX_FE" ]
+   then
+      # Modern feature extraction
+      mkdir -p feat logdir
+      $SPHINX_FE \
+         -c etc/${FV_VOICENAME}_train.fileids \
+         -di wav \
+         -ei wav \
+         -do feat \
+         -eo mfc \
+         -nist yes \
+         -samprate 16000 \
+         -nfilt 25 \
+         -lowerf 130 \
+         -upperf 6800 \
+         -nfft 512 \
+         -ncep 13 \
+         -transform dct
+   else
+      # Legacy feature extraction
+      ./bin/make_feats etc/$FV_VOICENAME.fileids
+   fi
+
+   cd ..
 fi
 
+# Train acoustic models
 if [ "$1" = "train" ]
 then
+   echo "Training acoustic models for alignment"
    cd st
-   ./scripts_pl/00.verify/verify_all.pl 
-   ./scripts_pl/01.vector_quantize/slave.VQ.pl
-   ./scripts_pl/02.ci_schmm/slave_convg.pl
-   ./scripts_pl/03.makeuntiedmdef/make_untied_mdef.pl
-   ./scripts_pl/04.cd_schmm_untied/slave_convg.pl
-   ./scripts_pl/05.buildtrees/make_questions.pl
-   ./scripts_pl/05.buildtrees/slave.treebuilder.pl
-   ./scripts_pl/06.prunetree/slave.state-tie-er.pl
-   ./scripts_pl/07.cd-schmm/slave_convg.pl
-   ./scripts_pl/08.deleted-interpolation/deleted_interpolation.pl
-   ./scripts_pl/09.make_s2_models/make_s2_models.pl
+
+   if [ "$USE_SPHINX3" = 1 ] && [ "$SPHINXTRAIN_PY" ]
+   then
+      # Modern training - CI HMM for forced alignment
+      if grep -q "CFG_FORCEDALIGN = 'no'" etc/sphinx_train.cfg 2>/dev/null; then
+         sed -i.bak "s/\$CFG_FORCEDALIGN = 'no';/\$CFG_FORCEDALIGN = 'yes';/" etc/sphinx_train.cfg
+         echo "Enabled forced alignment mode"
+      fi
+      $SPHINXTRAIN_PY -s 00.verify run
+      $SPHINXTRAIN_PY -s 10.falign_ci_hmm run
+   else
+      # Legacy training - full pipeline
+      ./scripts_pl/00.verify/verify_all.pl
+      ./scripts_pl/01.vector_quantize/slave.VQ.pl
+      ./scripts_pl/02.ci_schmm/slave_convg.pl
+      ./scripts_pl/03.makeuntiedmdef/make_untied_mdef.pl
+      ./scripts_pl/04.cd_schmm_untied/slave_convg.pl
+      ./scripts_pl/05.buildtrees/make_questions.pl
+      ./scripts_pl/05.buildtrees/slave.treebuilder.pl
+      ./scripts_pl/06.prunetree/slave.state-tie-er.pl
+      ./scripts_pl/07.cd-schmm/slave_convg.pl
+      ./scripts_pl/08.deleted-interpolation/deleted_interpolation.pl
+      ./scripts_pl/09.make_s2_models/make_s2_models.pl
+   fi
+
    cd ..
 fi
 
 # Alignment
 if [ "$1" = "align" ]
 then
-   echo "*align_all*" >st/etc/$FV_VOICENAME.align
-   cat st/etc/$FV_VOICENAME.transcription |
-   sed 's/<sil>//g' |
-   awk '{for (i=2; i<NF-2; i++)
-           printf("%s ",$i);
-         printf("%s\n",$(NF-2))}' >>st/etc/$FV_VOICENAME.align
-   echo "<sil> SIL" >st/etc/$FV_VOICENAME.sil
-   ./bin/sphinx_lab 
+   cd st
+   mkdir -p falignout phseg wdseg
+
+   if [ "$USE_SPHINX3" = 1 ]
+   then
+      echo "Running forced alignment with sphinx3_align (multi-pronunciation)"
+
+      # Use multi-pron files if they exist
+      if [ -f etc/$FV_VOICENAME.multipron.transcription ]; then
+         echo "  Using multi-pronunciation transcript"
+         cp etc/$FV_VOICENAME.multipron.transcription falignout/$FV_VOICENAME.aligninput
+      else
+         cp etc/$FV_VOICENAME.transcription falignout/$FV_VOICENAME.aligninput
+      fi
+
+      if [ -f etc/$FV_VOICENAME.multipron.dic ]; then
+         echo "  Using multi-pronunciation dictionary"
+         cp etc/$FV_VOICENAME.multipron.dic falignout/$FV_VOICENAME.falign.dict
+      else
+         cp etc/$FV_VOICENAME.dic falignout/$FV_VOICENAME.falign.dict
+      fi
+
+      # Filler dictionary
+      echo "<s> SIL" > falignout/$FV_VOICENAME.falign.fdict
+      echo "</s> SIL" >> falignout/$FV_VOICENAME.falign.fdict
+      echo "<sil> SIL" >> falignout/$FV_VOICENAME.falign.fdict
+
+      HMM_DIR=model_parameters/${FV_VOICENAME}.falign_ci_cont
+
+      $SPHINX3_ALIGN \
+         -hmm $HMM_DIR \
+         -dict falignout/$FV_VOICENAME.falign.dict \
+         -fdict falignout/$FV_VOICENAME.falign.fdict \
+         -ctl etc/${FV_VOICENAME}_train.fileids \
+         -insent falignout/$FV_VOICENAME.aligninput \
+         -outsent falignout/$FV_VOICENAME.alignoutput \
+         -cepdir feat \
+         -cepext .mfc \
+         -phsegdir phseg,CTL \
+         -wdsegdir wdseg,CTL \
+         -beam 1e-200 \
+         -agc none \
+         -cmn batch \
+         -feat 1s_c_d_dd \
+         -ceplen 13 \
+         -logbase 1.0001
+
+      echo ""
+      echo "Alignment output:"
+      echo "  falignout/$FV_VOICENAME.alignoutput - selected pronunciations"
+      echo "  phseg/ - phone-level alignments"
+      echo "  wdseg/ - word-level alignments"
+
+   else
+      echo "Running forced alignment with sphinx2-batch (legacy)"
+
+      # Legacy alignment setup
+      echo "*align_all*" >etc/$FV_VOICENAME.align
+      cat etc/$FV_VOICENAME.transcription |
+      sed 's/<sil>//g' |
+      awk '{for (i=2; i<NF-2; i++)
+              printf("%s ",$i);
+            printf("%s\n",$(NF-2))}' >>etc/$FV_VOICENAME.align
+      echo "<sil> SIL" >etc/$FV_VOICENAME.sil
+
+      cd ..
+      ./bin/sphinx_lab
+      cd st
+   fi
+
+   cd ..
 fi
 
-# Copy back lab files
+# Convert labels to FestVox format
 if [ "$1" = "labs" ]
 then
-   echo Convert Sphinx2 lab output to FestVox labs
-   silence=`head -1 etc/mysilence`
-   for i in st/lab/*.lab
-   do
-     cat $i | sed 's/;.*$//;s/(.*$//' | 
-              sed 's/SIL/'$silence'/;s/CAP//' |
-     awk '{if (NF == 3)
-             printf("%1.5f %s %s\n",0.012+$1,$2,$3);
-           else
-             print $0}' >lab/`basename $i`
-   done
+   echo "Converting labels to FestVox format"
+   silence=$(head -1 etc/mysilence)
+   mkdir -p lab wrd
+
+   if [ "$USE_SPHINX3" = 1 ] && [ -d st/phseg ]
+   then
+      # Convert phseg format to lab format
+      for phseg in st/phseg/*.phseg
+      do
+         base=$(basename $phseg .phseg)
+         echo "#" > lab/$base.lab
+         awk -v sil="$silence" '
+            BEGIN { frame_shift = 0.01 }
+            /^[ \t]*[0-9]/ {
+               gsub(/^[ \t]+/, "")
+               split($0, fields)
+               end = (fields[2] + 1) * frame_shift
+               phone = fields[4]
+               if (phone == "SIL") phone = sil
+               gsub(/^CAP/, "", phone)
+               printf("%1.5f 125 %s\n", end, phone)
+            }
+         ' $phseg >> lab/$base.lab
+      done
+
+      # Convert wdseg to wrd format
+      if [ -d st/wdseg ]; then
+         for wdseg in st/wdseg/*.wdseg
+         do
+            base=$(basename $wdseg .wdseg)
+            awk '
+               BEGIN { frame_shift = 0.01 }
+               /^[ \t]*[0-9]/ {
+                  gsub(/^[ \t]+/, "")
+                  split($0, fields)
+                  end = (fields[2] + 1) * frame_shift
+                  word = fields[4]
+                  if (word ~ /^<.*>$/) next
+                  gsub(/\([0-9]+\)$/, "", word)
+                  word = tolower(word)
+                  printf("%1.5f 125 %s\n", end, word)
+               }
+            ' $wdseg > wrd/$base.wrd
+         done
+         echo "Word boundaries written to wrd/ ($(ls wrd/*.wrd 2>/dev/null | wc -l | tr -d ' ') files)"
+      fi
+
+   else
+      # Legacy lab format conversion
+      for i in st/lab/*.lab
+      do
+         cat $i | sed 's/;.*$//;s/(.*$//' |
+            sed 's/SIL/'$silence'/;s/CAP//' |
+         awk '{if (NF == 3)
+                 printf("%1.5f %s %s\n",0.012+$1,$2,$3);
+               else
+                 print $0}' >lab/$(basename $i)
+      done
+   fi
+
+   echo "Labels written to lab/ ($(ls lab/*.lab 2>/dev/null | wc -l | tr -d ' ') files)"
+fi
+
+# Help
+if [ "$1" = "help" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]
+then
+   echo "Usage: sphinxtrain [step]"
+   echo ""
+   echo "SphinxTrain-based forced alignment with multi-pronunciation support."
+   echo "Automatically uses sphinx3_align (modern) or sphinx2-batch (legacy)."
+   echo ""
+   echo "Default pipeline (run with no arguments):"
+   echo "  setup     - Initialize SphinxTrain directory"
+   echo "  files     - Generate dictionary, phone list, transcriptions"
+   echo "  multipron - Convert to WORD(n) format for multi-pronunciation"
+   echo "  feats     - Extract MFCC features"
+   echo "  train     - Train CI acoustic models"
+   echo "  align     - Align with multiple prons + silence insertion"
+   echo "  labs      - Convert labels to FestVox format"
+   echo ""
+   echo "Multi-pronunciation alignment allows SphinxTrain to:"
+   echo "  - Choose between alternate pronunciations acoustically"
+   echo "  - Insert optional silences between words"
+   echo "  - Correct stress based on selected pronunciation"
+   echo ""
+   echo "Output files:"
+   echo "  lab/*.lab - Phone-level alignments (FestVox format)"
+   echo "  wrd/*.wrd - Word-level alignments"
+   echo "  st/falignout/*.alignoutput - Selected pronunciations (WORD(n))"
+   echo "  st/etc/*.stressmap - Stress patterns for correction"
 fi

--- a/src/st/sphinxtrain
+++ b/src/st/sphinxtrain
@@ -171,19 +171,27 @@ then
 fi
 
 # Create multi-pronunciation files for downstream steps
-# With build_st_multipron.scm, the dictionary is already in WORD(n) format,
-# so we just copy the files (for compatibility with steps expecting .multipron.dic)
+# Detects if dict already has WORD(n) format (from build_st_multipron.scm)
+# or needs sed conversion (from build_st.scm fallback)
 if [ "$1" = "multipron" ]
 then
    echo "Creating multi-pronunciation files for alignment"
    cd st
 
-   # Dictionary is already in WORD(n) format from build_st_multipron.scm
-   # Just copy to .multipron.dic for downstream compatibility
-   cp etc/$FV_VOICENAME.dic etc/$FV_VOICENAME.multipron.dic
-
-   # Transcription uses base word forms (aligner picks WORD(n) from dict)
-   cp etc/$FV_VOICENAME.transcription etc/$FV_VOICENAME.multipron.transcription
+   # Check if dictionary already has WORD(n) format
+   if grep -q '([0-9])' etc/$FV_VOICENAME.dic; then
+      echo "  Dictionary already in WORD(n) format, copying..."
+      cp etc/$FV_VOICENAME.dic etc/$FV_VOICENAME.multipron.dic
+      cp etc/$FV_VOICENAME.transcription etc/$FV_VOICENAME.multipron.transcription
+   else
+      echo "  Converting dictionary to WORD(n) format..."
+      # Convert dict: WORD2 -> WORD(2) format for SphinxTrain
+      sed -E 's/^([A-Z]+Q?)([0-9]+)  /\1(\2)  /' etc/$FV_VOICENAME.dic \
+         > etc/$FV_VOICENAME.multipron.dic
+      # Convert transcript: strip trailing digits from words
+      sed -E 's/([A-Z]+Q?)[0-9]+/\1/g' etc/$FV_VOICENAME.transcription \
+         > etc/$FV_VOICENAME.multipron.transcription
+   fi
 
    cd ..
 

--- a/src/st/sphinxtrain
+++ b/src/st/sphinxtrain
@@ -141,10 +141,28 @@ then
 fi
 
 # Generate dictionary, phone list, transcription files
+# Uses build_st_multipron.scm which gets ALL pronunciations from lexicon via lex.lookup_all
+# Dictionary is generated in WORD(n) format directly (e.g., READ, READ(2), READ(3))
 if [ "$1" = "files" ]
 then
-   echo "Generating SphinxTrain input files"
-   festival -b festvox/build_st.scm '(st_setup "etc/txt.done.data" "'$FV_VOICENAME'")'
+   echo "Generating SphinxTrain input files (multi-pronunciation)"
+   
+   # Copy build_st_multipron.scm if not present
+   if [ ! -f festvox/build_st_multipron.scm ]; then
+      if [ -f "$FESTVOXDIR/src/st/build_st_multipron.scm" ]; then
+         cp "$FESTVOXDIR/src/st/build_st_multipron.scm" festvox/
+      fi
+   fi
+   
+   # Use multi-pronunciation setup - generates WORD(n) format directly
+   if [ -f festvox/build_st_multipron.scm ]; then
+      festival -b festvox/build_st_multipron.scm \
+         '(st_multipron_setup "etc/txt.done.data" "'$FV_VOICENAME'")'
+   else
+      # Fallback to standard setup
+      echo "Warning: build_st_multipron.scm not found, using standard setup"
+      festival -b festvox/build_st.scm '(st_setup "etc/txt.done.data" "'$FV_VOICENAME'")'
+   fi
 
    # Copy to expected locations
    cp st/etc/$FV_VOICENAME.phone st/etc/${FV_VOICENAME}.phone 2>/dev/null
@@ -152,37 +170,29 @@ then
    cp st/etc/$FV_VOICENAME.transcription st/etc/${FV_VOICENAME}_train.transcription 2>/dev/null
 fi
 
-# Convert to multi-pronunciation format (WORD2 -> WORD(2))
+# Create multi-pronunciation files for downstream steps
+# With build_st_multipron.scm, the dictionary is already in WORD(n) format,
+# so we just copy the files (for compatibility with steps expecting .multipron.dic)
 if [ "$1" = "multipron" ]
 then
-   echo "Creating multi-pronunciation dictionary and transcript"
+   echo "Creating multi-pronunciation files for alignment"
    cd st
 
-   # Convert dict: WORD2 -> WORD(2) format for SphinxTrain
-   sed -E 's/^([A-Z]+Q?)([0-9]+)  /\1(\2)  /' etc/$FV_VOICENAME.dic \
-      > etc/$FV_VOICENAME.multipron.dic
+   # Dictionary is already in WORD(n) format from build_st_multipron.scm
+   # Just copy to .multipron.dic for downstream compatibility
+   cp etc/$FV_VOICENAME.dic etc/$FV_VOICENAME.multipron.dic
 
-   # Convert transcript: strip trailing digits from words
-   sed -E 's/([A-Z]+Q?)[0-9]+/\1/g' etc/$FV_VOICENAME.transcription \
-      > etc/$FV_VOICENAME.multipron.transcription
+   # Transcription uses base word forms (aligner picks WORD(n) from dict)
+   cp etc/$FV_VOICENAME.transcription etc/$FV_VOICENAME.multipron.transcription
 
    cd ..
-
-   # Generate stress map for pronunciation variants
-   echo "Generating stress map for pronunciation variants..."
-   if [ -f "$FESTVOXDIR/src/st/build_stress_map.scm" ]; then
-      cp $FESTVOXDIR/src/st/build_stress_map.scm festvox/
-   fi
-
-   if [ -f "festvox/build_stress_map.scm" ]; then
-      festival -b festvox/build_stress_map.scm \
-         '(build_stress_map "etc/txt.done.data" "st/etc/'$FV_VOICENAME'.stressmap")'
-   fi
 
    echo "Created:"
    echo "  st/etc/$FV_VOICENAME.multipron.dic - WORD(n) format dictionary"
    echo "  st/etc/$FV_VOICENAME.multipron.transcription - base word forms"
-   echo "  st/etc/$FV_VOICENAME.stressmap - stress patterns for variants"
+   echo ""
+   echo "Note: Stress can be recovered from selected variant (e.g., RECORD(2))"
+   echo "      by calling (nth 1 (lex.lookup_all \"record\")) in Festival"
 fi
 
 # Extract features

--- a/src/st/sphinxtrain
+++ b/src/st/sphinxtrain
@@ -234,29 +234,35 @@ then
    echo "Training acoustic models for alignment"
    cd st
 
-   if [ "$USE_SPHINX3" = 1 ] && [ "$SPHINXTRAIN_PY" ]
-   then
-      # Modern training - CI HMM for forced alignment
-      if grep -q "CFG_FORCEDALIGN = 'no'" etc/sphinx_train.cfg 2>/dev/null; then
+   # Enable forced alignment mode in sphinx_train.cfg
+   if [ -f etc/sphinx_train.cfg ]; then
+      if grep -q "\$CFG_FORCEDALIGN = 'no'" etc/sphinx_train.cfg; then
          sed -i.bak "s/\$CFG_FORCEDALIGN = 'no';/\$CFG_FORCEDALIGN = 'yes';/" etc/sphinx_train.cfg
-         echo "Enabled forced alignment mode"
+         echo "  Enabled forced alignment mode"
       fi
-      $SPHINXTRAIN_PY -s 00.verify run
-      $SPHINXTRAIN_PY -s 10.falign_ci_hmm run
-   else
-      # Legacy training - full pipeline
-      ./scripts_pl/00.verify/verify_all.pl
-      ./scripts_pl/01.vector_quantize/slave.VQ.pl
-      ./scripts_pl/02.ci_schmm/slave_convg.pl
-      ./scripts_pl/03.makeuntiedmdef/make_untied_mdef.pl
-      ./scripts_pl/04.cd_schmm_untied/slave_convg.pl
-      ./scripts_pl/05.buildtrees/make_questions.pl
-      ./scripts_pl/05.buildtrees/slave.treebuilder.pl
-      ./scripts_pl/06.prunetree/slave.state-tie-er.pl
-      ./scripts_pl/07.cd-schmm/slave_convg.pl
-      ./scripts_pl/08.deleted-interpolation/deleted_interpolation.pl
-      ./scripts_pl/09.make_s2_models/make_s2_models.pl
    fi
+
+   # Find the training script - modern SphinxTrain uses scripts/10.falign_ci_hmm/
+   TRAIN_SCRIPT=""
+   if [ -f "$SPHINXTRAINDIR/scripts/10.falign_ci_hmm/slave_convg.pl" ]; then
+      TRAIN_SCRIPT="$SPHINXTRAINDIR/scripts/10.falign_ci_hmm/slave_convg.pl"
+   elif [ -f "$SPHINXTRAINDIR/scripts_pl/10.falign_ci_hmm/slave_convg.pl" ]; then
+      TRAIN_SCRIPT="$SPHINXTRAINDIR/scripts_pl/10.falign_ci_hmm/slave_convg.pl"
+   elif [ -f scripts_pl/02.ci_schmm/slave_convg.pl ]; then
+      # Legacy local scripts
+      TRAIN_SCRIPT="scripts_pl/02.ci_schmm/slave_convg.pl"
+   fi
+
+   if [ -z "$TRAIN_SCRIPT" ]; then
+      echo "Error: Cannot find SphinxTrain training script"
+      echo "  Checked: $SPHINXTRAINDIR/scripts/10.falign_ci_hmm/slave_convg.pl"
+      echo "  Checked: $SPHINXTRAINDIR/scripts_pl/10.falign_ci_hmm/slave_convg.pl"
+      cd ..
+      exit 1
+   fi
+
+   echo "  Running: perl $TRAIN_SCRIPT"
+   perl "$TRAIN_SCRIPT"
 
    cd ..
 fi

--- a/src/st/sphinxtrain
+++ b/src/st/sphinxtrain
@@ -271,6 +271,9 @@ fi
 if [ "$1" = "align" ]
 then
    cd st
+   
+   # Clear old alignment files
+   rm -rf falignout phseg wdseg 2>/dev/null
    mkdir -p falignout phseg wdseg
 
    if [ "$USE_SPHINX3" = 1 ]
@@ -348,6 +351,9 @@ if [ "$1" = "labs" ]
 then
    echo "Converting labels to FestVox format"
    silence=$(head -1 etc/mysilence)
+   
+   # Clear old files to ensure fresh generation
+   rm -f lab/*.lab wrd/*.wrd 2>/dev/null
    mkdir -p lab wrd
 
    if [ "$USE_SPHINX3" = 1 ] && [ -d st/phseg ]

--- a/src/st/sphinxtrain
+++ b/src/st/sphinxtrain
@@ -320,6 +320,11 @@ then
          -ceplen 13 \
          -logbase 1.0001
 
+      # sphinx3_align echoes <s>/<\/s>, fix doubled markers in output
+      sed -i.bak 's/^<s> <s> /<s> /; s/ <\/s> <\/s> / <\/s> /' \
+         falignout/$FV_VOICENAME.alignoutput
+      rm -f falignout/$FV_VOICENAME.alignoutput.bak
+
       echo ""
       echo "Alignment output:"
       echo "  falignout/$FV_VOICENAME.alignoutput - selected pronunciations"

--- a/src/unitsel/setup_clunits
+++ b/src/unitsel/setup_clunits
@@ -152,10 +152,13 @@ cp -p $FESTVOXDIR/src/general/prune_silence bin
 cp -p $FESTVOXDIR/src/general/prune_middle_silences bin
 cp -p $FESTVOXDIR/src/general/add_noise bin
 
-# We don't use sphinxtrain anymore for labeling
-#cp -p $FESTVOXDIR/src/st/sphinxtrain bin
-#cp -p $FESTVOXDIR/src/st/sphinx_lab bin
-#cp -p $FESTVOXDIR/src/st/build_st.scm festvox
+# SphinxTrain-based labeling (alternative to EHMM, supports multi-pronunciation)
+cp -p $FESTVOXDIR/src/st/sphinxtrain bin
+cp -p $FESTVOXDIR/src/st/sphinx_lab bin
+cp -p $FESTVOXDIR/src/st/build_st.scm festvox
+if [ -f $FESTVOXDIR/src/st/build_stress_map.scm ]; then
+    cp -p $FESTVOXDIR/src/st/build_stress_map.scm festvox
+fi
 
 if [ "$FESTVOXTEMPLATEDIR" = "" ]
 then


### PR DESCRIPTION
## Description

Updates the `sphinxtrain` script to support modern SphinxTrain (5.x) with multi-pronunciation alignment and automatic silence insertion.

### Key Changes

**Multi-Pronunciation Alignment**
- SphinxTrain can now acoustically select between alternate pronunciations
- Example: For "I tried to READ", selects `READ(2)` [r iy d] vs `READ` [r eh d] based on audio

**Automatic Silence Detection**
- Inserts `<sil>` markers at natural pauses not in the transcript
- Example: `ROBBERY <sil> BRIBERY FRAUD`

**Stress Correction**
- Generates stress map for pronunciation variants (e.g., `RECORD (1 0)` vs `RECORD(2) (0 1)`)
- Enables correcting syllable stress based on acoustically-selected variant

**Modern SphinxTrain Support**
- Auto-detects `sphinx3_align` (modern) vs `sphinx2-batch` (legacy)
- Uses `sphinx_fe` for feature extraction
- Maintains backward compatibility with Sphinx2

### New Files

| File | Purpose |
|------|---------|
| `src/st/build_st_multipron.scm` | Generate WORD(n) format dictionary |
| `src/st/build_stress_map.scm` | Extract stress patterns for variants |
| `src/st/align_with_stress.scm` | Merge alignments with stress correction |
| `SPHINXTRAIN_UPDATE.md` | Documentation |

### Usage

```bash
# Default pipeline (multi-pronunciation)
bin/sphinxtrain

# Individual steps
bin/sphinxtrain setup
bin/sphinxtrain files
bin/sphinxtrain multipron
bin/sphinxtrain feats
bin/sphinxtrain train
bin/sphinxtrain align
bin/sphinxtrain labs
```

## Verification steps

1. Build a voice with SphinxTrain alignment:
   ```bash
   export SPHINXTRAINDIR=/path/to/sphinxtrain
   bin/sphinxtrain
   ```

2. Check multi-pronunciation selection in output:
   ```bash
   grep '([0-9])' st/falignout/*.alignoutput | head
   ```

3. Verify silence insertion:
   ```bash
   grep '<sil>' st/falignout/*.alignoutput | head
   ```

4. Confirm lab files generated:
   ```bash
   ls lab/*.lab | wc -l
   ```

